### PR TITLE
Issue #5 Plugin doesn't work properly in non-US locales.

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ module.exports = function(app) {
               }
               newPath = newPath + "core." + (Number(spl_line[1])+1).toString()
               newPath = newPath + "." + pathArray[(pathArray.length-1)]
-              var cpu_util_core = ((100 - Number(spl_line[11]))/100).toFixed(2)
+		var cpu_util_core = ((100 - Number(spl_line[11].replace(/,/, '.')))/100).toFixed(2)
               app.handleMessage(plugin.id, {
                 updates: [
                   {
@@ -218,7 +218,7 @@ module.exports = function(app) {
             }
             else {
               debug(`cpu utilisation is ${spl_line[11]}`)
-              cpu_util_all = ((100 - Number(spl_line[11]))/100).toFixed(2)
+		cpu_util_all = ((100 - Number(spl_line[11].replace(/,/, '.')))/100).toFixed(2)
               app.handleMessage(plugin.id, {
                 updates: [
                   {

--- a/index.js
+++ b/index.js
@@ -248,43 +248,43 @@ module.exports = function(app) {
 
       memutil.stdout.on('data', (data) => {
         debug(`got memory  ${data}`)
-          var mem_util = data.toString().replace(/(\n|\r)+$/, '').split('\n')
-	  var mem_total
-	  var mem_free
-	  var buffers
-	  var cached
-	  var slab
+        var mem_util = data.toString().replace(/(\n|\r)+$/, '').split('\n')
+        var mem_total
+        var mem_free
+        var buffers
+        var cached
+        var slab
         mem_util.forEach(function(mem_util_line) {
-            var splm_line = mem_util_line.replace(/ +/g, ' ').split(' ')
-            if (splm_line[0].toString() === "MemTotal:") {
-		mem_total = Number(splm_line[1])
-		debug(`got mem_total = ${mem_total}`)
-	    } else if (splm_line[0].toString() === "MemFree:") {
-		mem_free = Number(splm_line[1])
-		debug(`got mem_free = ${mem_free}`)
-            } else if (splm_line[0].toString() === "Buffers:") {
-                buffers = Number(splm_line[1])
-                debug(`got buffers = ${buffers}`)
-            } else if (splm_line[0].toString() === "Cached:") {
-                cached = Number(splm_line[1])
-                debug(`got cached = ${cached}`)
-            } else if (splm_line[0].toString() === "Slab:") {
-                slab = Number(splm_line[1])
-                debug(`got slab = ${slab}`)
-	    }
+          var splm_line = mem_util_line.replace(/ +/g, ' ').split(' ')
+          if (splm_line[0].toString() === "MemTotal:") {
+            mem_total = Number(splm_line[1])
+            debug(`got mem_total = ${mem_total}`)
+	  } else if (splm_line[0].toString() === "MemFree:") {
+	    mem_free = Number(splm_line[1])
+	    debug(`got mem_free = ${mem_free}`)
+          } else if (splm_line[0].toString() === "Buffers:") {
+            buffers = Number(splm_line[1])
+            debug(`got buffers = ${buffers}`)
+          } else if (splm_line[0].toString() === "Cached:") {
+            cached = Number(splm_line[1])
+            debug(`got cached = ${cached}`)
+          } else if (splm_line[0].toString() === "Slab:") {
+            slab = Number(splm_line[1])
+            debug(`got slab = ${slab}`)
+	  }
 	})
-	  var mem_util_per = ((mem_total - (mem_free + buffers + cached + slab))/mem_total).toFixed(2)
+	var mem_util_per = ((mem_total - (mem_free + buffers + cached + slab))/mem_total).toFixed(2)
 	debug(`mem_util_per: ${mem_util_per}`)
 	    
         app.handleMessage(plugin.id, {
-            updates: [
-                {
-                values: [ {
-                  path: options.path_mem_util,
-                  value: Number(mem_util_per)
-                }]
-              }
-            ]
+          updates: [
+            {
+              values: [ {
+                path: options.path_mem_util,
+                value: Number(mem_util_per)
+              }]
+            }
+          ]
         })
       })
       memutil.on('error', (error) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-rpi-monitor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Signal K Node Server Plugin for Raspberry PI monitoring",
   "homepage": "https://github.com/sberl/signalk-rpi-monitor#readme",
   "keywords": [


### PR DESCRIPTION
This is a fix to Issue #5 where on systems using a German locale, and probably many other non-US locales, the parsing of CPU and memory utilization was failing. 
For the CPU I was parsing the output of the mpstat command, which included some decimal numbers. But in many locales, the comma is used as a decimal separator instead of the period character. 
The fix was to change , to . before attempting to parse the strings.

For the memory utilization the problem was I was looking at the output of the free command, but in other locales, the labels are translated into other languages. For this one I found that the output of 'cat /proc/meminfo' gives a consistent label in all locales, so I changed the code to parse this.